### PR TITLE
Fix production app url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/tbruyelle/yousign
 
 go 1.12
 
-require github.com/google/go-querystring v1.0.0
+require (
+	github.com/bxcodec/faker/v3 v3.6.0
+	github.com/google/go-querystring v1.0.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,15 @@
+github.com/bxcodec/faker/v3 v3.6.0 h1:Meuh+M6pQJsQJwxVALq6H5wpDzkZ4pStV9pmH7gbKKs=
+github.com/bxcodec/faker/v3 v3.6.0/go.mod h1:gF31YgnMSMKgkvl+fyEo1xuSMbEuieyqfeslGYFjneM=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yousign.go
+++ b/yousign.go
@@ -17,7 +17,7 @@ const (
 	productionApiURL = "https://api.yousign.com"
 
 	stagingAppURL    = "https://staging-app.yousign.com"
-	productionAppURL = "https://api.yousign.com"
+	productionAppURL = "https://webapp.yousign.com"
 )
 
 type Client struct {

--- a/yousign_test.go
+++ b/yousign_test.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -15,4 +18,30 @@ func fatal(t *testing.T, err error, resp *http.Response) {
 	var b bytes.Buffer
 	io.Copy(&b, resp.Body)
 	t.Fatalf("error %v : %s", err, b.String())
+}
+
+func TestCorrectStagingSigningURL(t *testing.T) {
+	assert := assert.New(t)
+
+	apiKey := faker.UUIDHyphenated()
+	client := NewClientStaging(apiKey)
+	memberID := faker.UUIDHyphenated()
+
+	signURL := client.SignURL(memberID)
+
+	expectedURL := "https://staging-app.yousign.com/procedure/sign?members=" + memberID
+	assert.Equal(expectedURL, signURL)
+}
+
+func TestCorrectProductionSigningURL(t *testing.T) {
+	assert := assert.New(t)
+
+	apiKey := faker.UUIDHyphenated()
+	client := NewClient(apiKey)
+	memberID := faker.UUIDHyphenated()
+
+	signURL := client.SignURL(memberID)
+
+	expectedURL := "https://webapp.yousign.com/procedure/sign?members=" + memberID
+	assert.Equal(expectedURL, signURL)
 }


### PR DESCRIPTION
Hi 👋 !
When I switched to production I encountered some issues when trying to access the signing URL.
I found that `productionAppURL` value was incorrect. In this Pull Request I fix the value of this variable and I write two tests to ensure `Client.SignURL()` method always returns the URL we want.
This time I have not updated the name of the go module with the one of my fork!

I hope you agree with my changes and I stay available to perform the updates you want.

See you!